### PR TITLE
fix ignoring of keywords inside comments

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -284,6 +284,14 @@ end"
     end
 end"))
 
+(ert-deftest julia--test-indent-after-commented-keyword ()
+  "Ignore keywords in comments when indenting."
+  (julia--should-indent
+   "# if foo
+a = 1"
+   "# if foo
+a = 1"))
+
 (defun julia--run-tests ()
   (interactive)
   (if (featurep 'ert)

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -408,8 +408,8 @@ a keyword if used as a field name, X.word, or quoted, :word."
        (member (current-word t) kw-list)
        ;; 'end' is not a keyword when used for indexing, e.g. foo[end-2]
        (or (not (equal (current-word t) "end"))
-           (not (julia-in-brackets))
-           (not (julia-in-comment)))))
+           (not (julia-in-brackets)))
+       (not (julia-in-comment))))
 
 ;; if backward-sexp gives an error, move back 1 char to move over the '('
 (defun julia-safe-backward-sexp ()


### PR DESCRIPTION
This was part of the fix for https://github.com/JuliaLang/julia/issues/15461, but I just noticed that it doesn't work, due to a mis-nesting of this clause.