### PR TITLE
`python-mode`-like paren-indent

### DIFF
--- a/julia-mode-tests.el
+++ b/julia-mode-tests.el
@@ -183,6 +183,29 @@ baz )"
 foobar( bar,
         baz )"))
 
+(ert-deftest julia--test-indent-paren-newline ()
+  "python-mode-like indentation."
+  (julia--should-indent
+     "
+foobar(
+bar,
+baz)"
+     "
+foobar(
+    bar,
+    baz)")
+  (julia--should-indent
+     "
+foobar(
+bar,
+baz
+)"
+     "
+foobar(
+    bar,
+    baz
+)"))
+
 (ert-deftest julia--test-indent-equals ()
   "We should increase indent on a trailing =."
   (julia--should-indent

--- a/julia-mode.el
+++ b/julia-mode.el
@@ -468,10 +468,26 @@ with it. Returns nil if we're not within nested parens."
             ((= (nth 0 parser-state) 0) nil) ;; top level
             (t
              (ignore-errors ;; return nil if any of these movements fail
-               (backward-up-list)
-               (forward-char)
+               (beginning-of-line)
                (skip-syntax-forward " ")
-               (current-column)))))))
+               (let ((possibly-close-paren-point (point)))
+                 (backward-up-list)
+                 (let ((open-paren-point (point)))
+                   (forward-char)
+                   (skip-syntax-forward " ")
+                   (if (eolp)
+                       (progn
+                         (up-list)
+                         (backward-char)
+                         (let ((paren-closed (= (point) possibly-close-paren-point)))
+                           (goto-char open-paren-point)
+                           (beginning-of-line)
+                           (skip-syntax-forward " ")
+                           (+ (current-column)
+                              (if paren-closed
+                                  0
+                                julia-indent-offset))))
+                     (current-column))))))))))
 
 (defun julia-prev-line-skip-blank-or-comment ()
   "Move point to beginning of previous line skipping blank lines


### PR DESCRIPTION
This commit provides the following indentation-style, which is similar to that of `python-mode`:

```julia
function1(a, b, c
          d, e, f)
function1(a, b, c
          d, e, f
          )
function2(
    a, b, c
    d, e, f)
function2(
    a, b, c
    d, e, f
)


for i in Float64[1, 2, 3, 4
                 5, 6, 7, 8]
end
for i in Float64[1, 2, 3, 4
                 5, 6, 7, 8
                 ]
end
for i in Float64[
    1, 2, 3, 4
    5, 6, 7, 8]
end
for i in Float64[
    1, 2, 3, 4
    5, 6, 7, 8
]
end


a = function3(function ()
              return 1
              end)
a = function3(function ()
              return 1
              end
              )
a = function4(
    function ()
    return 1
    end)
a = function4(
    function ()
    return 1
    end
)
```
